### PR TITLE
Support coherent zeroeth-day calculations

### DIFF
--- a/lib/clavius/calculation/days_from.rb
+++ b/lib/clavius/calculation/days_from.rb
@@ -5,6 +5,8 @@ module Clavius
       def initialize(schedule, number)
         @schedule = schedule
         @number   = Integer(number)
+
+        fail ArgumentError, 'negative number' if @number < 0
       end
 
       def before(origin)

--- a/lib/clavius/calculation/days_from.rb
+++ b/lib/clavius/calculation/days_from.rb
@@ -2,23 +2,45 @@ module Clavius
   module Calculation
     class DaysFrom
 
-      def initialize(schedule, number_of_days)
-        @schedule       = schedule
-        @number_of_days = Integer(number_of_days)
+      def initialize(schedule, number)
+        @schedule = schedule
+        @number   = Integer(number)
       end
 
-      def before(date)
-        schedule.before(date).take(number_of_days).to_a.last
+      def before(origin)
+        calculated_day(:before, origin)
       end
 
-      def after(date)
-        schedule.after(date).take(number_of_days).to_a.last
+      def after(origin)
+        calculated_day(:after, origin)
       end
 
       protected
 
       attr_reader :schedule,
-                  :number_of_days
+                  :number
+
+      private
+
+      def calculated_day(direction, origin)
+        return zeroeth_day(direction, origin) if number.zero?
+
+        schedule.public_send(direction, origin).take(number).to_a.last
+      end
+
+      def zeroeth_day(direction, origin)
+        self
+          .class
+          .new(schedule, 1)
+          .public_send(direction, zeroeth_origin(direction, origin))
+      end
+
+      def zeroeth_origin(direction, origin)
+        case direction
+        when :before then origin.next_day
+        when :after  then origin.prev_day
+        end
+      end
 
     end
   end

--- a/spec/calculation/days_from_spec.rb
+++ b/spec/calculation/days_from_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe Clavius::Calculation::DaysFrom do
         expect { calculation }.to raise_error TypeError
       end
     end
+
+    context 'with a negative integer' do
+      let(:number) { -1 }
+
+      it 'fails hard' do
+        expect { calculation }.to raise_error ArgumentError
+      end
+    end
   end
 
   describe '#before' do

--- a/spec/calculation/days_from_spec.rb
+++ b/spec/calculation/days_from_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Clavius::Calculation::DaysFrom do
-  subject(:calculation) { described_class.new(schedule, number_of_days) }
+  subject(:calculation) { described_class.new(schedule, number) }
 
   let(:schedule) {
     Clavius::Schedule.new do |c|
@@ -9,11 +9,9 @@ RSpec.describe Clavius::Calculation::DaysFrom do
     end
   }
 
-  let(:number_of_days) { 10 }
-
   context 'when initializing' do
-    context 'with an integer number of days' do
-      let(:number_of_days) { 1 }
+    context 'with an integer' do
+      let(:number) { 1 }
 
       it 'is successful' do
         expect(calculation.after(Date.new(2012, 1, 1))).to eq(
@@ -23,7 +21,7 @@ RSpec.describe Clavius::Calculation::DaysFrom do
     end
 
     context 'with a valid integer-like value' do
-      let(:number_of_days) { '1' }
+      let(:number) { '1' }
 
       it 'is successful' do
         expect(calculation.after(Date.new(2012, 1, 1))).to eq(
@@ -33,7 +31,7 @@ RSpec.describe Clavius::Calculation::DaysFrom do
     end
 
     context 'with an invalid integer-like value' do
-      let(:number_of_days) { '1one' }
+      let(:number) { '1one' }
 
       it 'fails hard' do
         expect { calculation }.to raise_error ArgumentError
@@ -41,7 +39,7 @@ RSpec.describe Clavius::Calculation::DaysFrom do
     end
 
     context 'with a non-integer value' do
-      let(:number_of_days) { [] }
+      let(:number) { [] }
 
       it 'fails hard' do
         expect { calculation }.to raise_error TypeError
@@ -50,18 +48,66 @@ RSpec.describe Clavius::Calculation::DaysFrom do
   end
 
   describe '#before' do
-    it 'returns the date the number of active days before the origin date' do
-      expect(calculation.before(Date.new(2012, 1, 18))).to eq(
-        Date.new(2012, 1, 2)
-      )
+    context 'when the number is non-zero' do
+      let(:number) { 10 }
+
+      it 'returns the appropriate date before the origin' do
+        expect(calculation.before(Date.new(2012, 1, 18))).to eq(
+          Date.new(2012, 1, 2)
+        )
+      end
+    end
+
+    context 'when the number is zero' do
+      let(:number) { 0 }
+
+      context 'and the origin is active' do
+        let(:origin) { Date.new(2012, 1, 11) }
+
+        it 'returns the origin date' do
+          expect(calculation.before(origin)).to eq origin
+        end
+      end
+
+      context 'and the origin is inactive' do
+        let(:origin) { Date.new(2012, 1, 13) }
+
+        it 'returns the first active date before the origin' do
+          expect(calculation.before(origin)).to eq Date.new(2012, 1, 12)
+        end
+      end
     end
   end
 
   describe '#after' do
-    it 'returns the date the number of active days after the origin date' do
-      expect(calculation.after(Date.new(2012, 1, 2))).to eq(
-        Date.new(2012, 1, 18)
-      )
+    context 'when the number is non-zero' do
+      let(:number) { 10 }
+
+      it 'returns the appropriate date after the origin' do
+        expect(calculation.after(Date.new(2012, 1, 2))).to eq(
+          Date.new(2012, 1, 18)
+        )
+      end
+    end
+
+    context 'when the number is zero' do
+      let(:number) { 0 }
+
+      context 'and the origin is active' do
+        let(:origin) { Date.new(2012, 1, 11) }
+
+        it 'returns the origin' do
+          expect(calculation.after(origin)).to eq origin
+        end
+      end
+
+      context 'and the origin is inactive' do
+        let(:origin) { Date.new(2012, 1, 8) }
+
+        it 'returns the first active date after the origin' do
+          expect(calculation.after(origin)).to eq Date.new(2012, 1, 9)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, `nil` is returned when a calculation is performed in either direction where the provided number is zero.

Now, for zeroeth-day calculations, if the origin date is active, that date is returned; otherwise, the next active date in the specified direction is returned.

In addition, the validation logic has been tightened up to prevent calculations with negative numbers.

These changes will be used to address zendesk/biz#112.

@joshlam @alex-stone @sujaysudheenda @kbrainwave @lacco